### PR TITLE
Added getUserFavorite() and dislikeComment() to PostFireBase

### DIFF
--- a/Gauge/Feed/ViewModels/PostFirebase.swift
+++ b/Gauge/Feed/ViewModels/PostFirebase.swift
@@ -16,6 +16,23 @@ class PostFirebase: ObservableObject {
         Keys.fetchKeys()
     }
     
+    func dislikeComment(postId: String, commentId: String, userId: String) {
+        let commentRef = Firebase.db.collection("POSTS")
+            .document(postId)
+            .collection("COMMENTS")
+            .document(commentId)
+        
+        commentRef.updateData([
+            "dislikes": FieldValue.arrayUnion([userId])
+        ]) { error in
+            if let error = error {
+                print("Error disliking comment: \(error.localizedDescription)")
+            } else {
+                print("Successfully disliked the comment.")
+            }
+        }
+    }
+
     func getLiveFeedPosts(user: User) {
         let allPosts: [String] = user.myViews + user.myResponses
         Firebase.db.collection("POSTS").whereField("postId", notIn: allPosts.isEmpty ? [""] : allPosts).addSnapshotListener { snapshot, error in

--- a/Gauge/Feed/ViewModels/PostFirebase.swift
+++ b/Gauge/Feed/ViewModels/PostFirebase.swift
@@ -17,11 +17,18 @@ class PostFirebase: ObservableObject {
     }
     
     func dislikeComment(postId: String, commentId: String, userId: String) {
-        let commentRef = Firebase.db.collection("POSTS")
+        
+        // Reference a specific comment in the "COMMENTS" collection
+        // of a specific post in the "POSTS" collection
+        // from firebase database
+        let commentRef = Firebase.db
+            .collection("POSTS")
             .document(postId)
             .collection("COMMENTS")
             .document(commentId)
         
+        // use arrayUnion() to add userId to the dislikes field
+        // of the specific comment referenced aboved
         commentRef.updateData([
             "dislikes": FieldValue.arrayUnion([userId])
         ]) { error in
@@ -33,6 +40,26 @@ class PostFirebase: ObservableObject {
         }
     }
 
+    func getUserFavorites(userId: String) {
+        // Create an array to store favorite postId
+        var allFavoritePosts: [String] = []
+        // fetch all documents in the "POSTS" collection
+        // that have the "userId" in their "favoriteBy" field
+        Firebase.db.collection("POSTS")
+            .whereField("favoritedBy", arrayContains: userId)
+            .getDocuments { (snapshot, error) in
+                if let error = error {
+                    print("Error getting favorite posts: \(error)")
+                } else {
+                    for document in snapshot!.documents {
+                        allFavoritePosts.append(document.documentID)
+                    }
+                }
+            }
+    }
+    
+
+    
     func getLiveFeedPosts(user: User) {
         let allPosts: [String] = user.myViews + user.myResponses
         Firebase.db.collection("POSTS").whereField("postId", notIn: allPosts.isEmpty ? [""] : allPosts).addSnapshotListener { snapshot, error in
@@ -40,7 +67,7 @@ class PostFirebase: ObservableObject {
                 print("Error fetching post updates: \(error!)")
                 return
             }
-            
+    
             for change in snapshot.documentChanges {
                 if change.type == .added {
                     
@@ -52,6 +79,8 @@ class PostFirebase: ObservableObject {
             }
         }
     }
+    
+    
         
     func createBinaryPost(userId: String, category: Category, question: String, responseOption1: String, responseOption2: String) {
         // Create post instance

--- a/Gauge/Feed/Views/FirebaseTesting.swift
+++ b/Gauge/Feed/Views/FirebaseTesting.swift
@@ -36,6 +36,25 @@ struct FirebaseTesting: View {
                         upperBoundLabel: "Goated 🐐"
                     )
                 }
+                
+                Button("Fetch Favorite Post") {
+                    postVM.getUserFavorites(
+                        userId: "ExampleUser")
+                }
+                
+                Button("Like Comment") {
+                    postVM.dislikeComment(
+                        postId: "examplePost",
+                        commentId: "Ge3KON8x7l1jUUlpRvd7",
+                        userId: "Jack")
+                }
+                
+                Button("Dislike Comment") {
+                    postVM.dislikeComment(
+                        postId: "examplePost",
+                        commentId: "Ge3KON8x7l1jUUlpRvd7",
+                        userId: "Jack")
+                }
             }
             
             Section("Get Live Data (Great for feed & games!)") {


### PR DESCRIPTION
1/ getUserFavorite takes in the user id and return all post id that have the user id in their "favorite by" field.
2/ dislikeComment() takes in the user id the post id with the specific comment id being dislike and add the user id to the "dislike" field of that comment.
3/ added 3 button to test out "like comment", "dislike comment", and "fetch favorite post" to FireBaseTesting